### PR TITLE
fix(ci): escape commit message to prevent backtick command substitution

### DIFF
--- a/.github/actions/please-release/action.yml
+++ b/.github/actions/please-release/action.yml
@@ -35,9 +35,10 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        COMMIT_MSG: ${{ inputs.commit-message }}
       run: |
         set -euo pipefail
-        COMMIT_MSG="${{ inputs.commit-message }}"
+        # note: COMMIT_MSG comes from env to avoid backtick command substitution
         REPO_URL="https://github.com/${{ inputs.repository }}"
 
         # check if this is a release commit


### PR DESCRIPTION
- moved commit-message from shell interpolation to env variable
- prevents bash from interpreting backticks in commit messages as commands

Co-authored-by: Ulad Kasach <uladkasach@gmail.com>
