### PR TITLE
fix(repeatably): only throw on final attempt for SOME criteria

### DIFF
--- a/src/domain.operations/givenWhenThen.repeatably.jest.test.ts
+++ b/src/domain.operations/givenWhenThen.repeatably.jest.test.ts
@@ -49,6 +49,35 @@ describe('when.repeatably', () => {
 });
 
 /**
+ * .what = verify that criteria=SOME passes when later attempt succeeds
+ * .why = critical fix: jest should NOT count early attempt failures when a later attempt passes
+ *
+ * @see https://github.com/ehmpathy/test-fns/issues/TBD - repeatably SOME counts failed attempts
+ */
+describe('when.repeatably criteria=SOME early failure recovery', () => {
+  given('a flaky test that fails on attempt 1 but passes on attempt 2', () => {
+    // track which attempts ran
+    const attemptsRan: number[] = [];
+
+    when.repeatably({ attempts: 3, criteria: 'SOME' })(
+      'flaky operation',
+      ({ attempt }) => {
+        then('it eventually passes', () => {
+          attemptsRan.push(attempt);
+          // fail on attempt 1, pass on attempt 2+
+          expect(attempt).toBeGreaterThanOrEqual(2);
+        });
+      },
+    );
+
+    // verify behavior: attempt 1 failed (but didnt throw to jest), attempt 2 passed, attempt 3 skipped
+    afterAll(() => {
+      expect(attemptsRan).toEqual([1, 2]);
+    });
+  });
+});
+
+/**
  * .what = isolated describe block to prove all then blocks run together per attempt
  * .why = verifies N-describe architecture runs complete block per attempt
  */

--- a/src/domain.operations/givenWhenThen.repeatably.vitest.globals.test.ts
+++ b/src/domain.operations/givenWhenThen.repeatably.vitest.globals.test.ts
@@ -46,6 +46,31 @@ describe('when.repeatably', () => {
     });
   });
 
+  /**
+   * .what = verify that criteria=SOME passes when later attempt succeeds
+   * .why = critical fix: vitest should NOT count early attempt failures when a later attempt passes
+   */
+  given('criteria = SOME early failure recovery', () => {
+    // track which attempts ran
+    const attemptsRan: number[] = [];
+
+    when.repeatably({ attempts: 3, criteria: 'SOME' })(
+      'flaky operation',
+      ({ attempt }) => {
+        then('it eventually passes', () => {
+          attemptsRan.push(attempt);
+          // fail on attempt 1, pass on attempt 2+
+          expect(attempt).toBeGreaterThanOrEqual(2);
+        });
+      },
+    );
+
+    // verify behavior: attempt 1 failed (but didnt throw), attempt 2 passed, attempt 3 skipped
+    afterAll(() => {
+      expect(attemptsRan).toEqual([1, 2]);
+    });
+  });
+
   given('criteria = SOME with multiple then blocks', () => {
     // track which then blocks execute on which attempts
     const thenAExecutedAttempts: number[] = [];

--- a/src/domain.operations/givenWhenThen.ts
+++ b/src/domain.operations/givenWhenThen.ts
@@ -215,6 +215,9 @@ given.repeatably =
         criteria: 'SOME',
         anyAttemptPassed: false,
         thisAttemptFailed: false,
+        thisAttemptIndex: 0,
+        allAttemptsQuant: configuration.attempts,
+        anyError: null,
       };
 
       for (const attempt of getNumberRange({
@@ -226,9 +229,10 @@ given.repeatably =
           const path = getDescribePath();
           registryDescribeRepeatable.set(path, state);
 
-          // reset failure flag at start of this attempt's execution (not registration)
+          // reset failure flag and set current attempt at start of this attempt's run
           globals().beforeAll(() => {
             state.thisAttemptFailed = false;
+            state.thisAttemptIndex = attempt;
           });
 
           // mark success after attempt completes without failures
@@ -323,6 +327,9 @@ when.repeatably =
         criteria: 'SOME',
         anyAttemptPassed: false,
         thisAttemptFailed: false,
+        thisAttemptIndex: 0,
+        allAttemptsQuant: configuration.attempts,
+        anyError: null,
       };
 
       for (const attempt of getNumberRange({
@@ -334,9 +341,10 @@ when.repeatably =
           const path = getDescribePath();
           registryDescribeRepeatable.set(path, state);
 
-          // reset failure flag at start of this attempt's execution (not registration)
+          // reset failure flag and set current attempt at start of this attempt's run
           globals().beforeAll(() => {
             state.thisAttemptFailed = false;
+            state.thisAttemptIndex = attempt;
           });
 
           // mark success after attempt completes without failures
@@ -406,7 +414,15 @@ const then: Test = ((...input: TestInput<void>): void => {
           await (testFn as () => Promise<unknown>)();
         } catch (error) {
           repeatableCtx.thisAttemptFailed = true;
-          throw error;
+          // preserve first error for final attempt
+          if (!repeatableCtx.anyError && error instanceof Error) {
+            repeatableCtx.anyError = error;
+          }
+          // only throw on final attempt - earlier failures are retried
+          if (repeatableCtx.thisAttemptIndex === repeatableCtx.allAttemptsQuant) {
+            throw repeatableCtx.anyError ?? error;
+          }
+          // else: swallow error, let subsequent attempts try
         }
       }
     });
@@ -429,7 +445,15 @@ const then: Test = ((...input: TestInput<void>): void => {
           await (testFn as () => Promise<unknown>)();
         } catch (error) {
           repeatableCtx.thisAttemptFailed = true;
-          throw error;
+          // preserve first error for final attempt
+          if (!repeatableCtx.anyError && error instanceof Error) {
+            repeatableCtx.anyError = error;
+          }
+          // only throw on final attempt - earlier failures are retried
+          if (repeatableCtx.thisAttemptIndex === repeatableCtx.allAttemptsQuant) {
+            throw repeatableCtx.anyError ?? error;
+          }
+          // else: swallow error, let subsequent attempts try
         }
       }
     });

--- a/src/domain.operations/givenWhenThen.ts
+++ b/src/domain.operations/givenWhenThen.ts
@@ -419,7 +419,9 @@ const then: Test = ((...input: TestInput<void>): void => {
             repeatableCtx.anyError = error;
           }
           // only throw on final attempt - earlier failures are retried
-          if (repeatableCtx.thisAttemptIndex === repeatableCtx.allAttemptsQuant) {
+          if (
+            repeatableCtx.thisAttemptIndex === repeatableCtx.allAttemptsQuant
+          ) {
             throw repeatableCtx.anyError ?? error;
           }
           // else: swallow error, let subsequent attempts try
@@ -450,7 +452,9 @@ const then: Test = ((...input: TestInput<void>): void => {
             repeatableCtx.anyError = error;
           }
           // only throw on final attempt - earlier failures are retried
-          if (repeatableCtx.thisAttemptIndex === repeatableCtx.allAttemptsQuant) {
+          if (
+            repeatableCtx.thisAttemptIndex === repeatableCtx.allAttemptsQuant
+          ) {
             throw repeatableCtx.anyError ?? error;
           }
           // else: swallow error, let subsequent attempts try

--- a/src/domain.operations/registryDescribeRepeatable.ts
+++ b/src/domain.operations/registryDescribeRepeatable.ts
@@ -37,6 +37,24 @@ export interface RepeatableState {
    * .why = used to determine if this attempt should mark success
    */
   thisAttemptFailed: boolean;
+
+  /**
+   * .what = which attempt number is active now
+   * .why = used to determine if we should throw on failure (only on final attempt)
+   */
+  thisAttemptIndex: number;
+
+  /**
+   * .what = total number of attempts configured
+   * .why = used to determine if current attempt is final
+   */
+  allAttemptsQuant: number;
+
+  /**
+   * .what = error encountered in any failed attempt
+   * .why = preserve error to throw on final attempt if all fail
+   */
+  anyError: Error | null;
 }
 
 /**


### PR DESCRIPTION
fix(repeatably): only throw on final attempt for SOME criteria

- added thisAttemptIndex, allAttemptsQuant, anyError to RepeatableState
- then wrapper now catches errors on non-final attempts
- errors are preserved and thrown only on final attempt if all fail
- added early failure recovery tests for jest and vitest

---
🐢🌊 surfed in by seaturtle[bot]